### PR TITLE
add command to embiggen an emote

### DIFF
--- a/cogs/emote.py
+++ b/cogs/emote.py
@@ -534,6 +534,15 @@ class Emotes(commands.Cog):
 			f'Animated emotes: **{animated_emotes} / {emote_limit}** ({animated_left} left, {percent_animated}% full)\n'
 			f'Total: **{total_emotes} / {emote_limit * 2}**')
 
+	@commands.command(aliases=["embiggen"])
+	async def big(self, context, emote):
+		"""Shows the original image for the given emote.
+
+		emote: the emote to embiggen.
+		"""
+		emote = await self.parse_emote(context, emote)
+		await context.send(f'{emote.name}: {emote.url}')
+
 	async def parse_emote(self, context, name_or_emote):
 		match = utils.emote.RE_CUSTOM_EMOTE.match(name_or_emote)
 		if match:


### PR DESCRIPTION
This PR adds new command `em/big <emote>`, allowing users to download the given emote. Mainly intended for mobile users.